### PR TITLE
WIP: Fix axisconvert for vectors.

### DIFF
--- a/tests/test_vcs_axisconvert_2d.py
+++ b/tests/test_vcs_axisconvert_2d.py
@@ -10,7 +10,8 @@ class TestVCSAxisConvert(basevcstest.VCSBaseTest):
         method = method()
         f = cdms2.open(vcs.sample_data+"/ta_ncep_87-6-88-4.nc")
         data = f("ta", time=slice(0,1), longitude=(12,12,'cob'), squeeze=1)
-        if isinstance(method, vcs.vector.Gv):
+        if isinstance(method, vcs.vector.Gv) or \
+           isinstance(method, vcs.streamline.Gs):
             data2 = data
         else:
             data2 = None
@@ -20,7 +21,8 @@ class TestVCSAxisConvert(basevcstest.VCSBaseTest):
         method = method()
         f = cdms2.open(vcs.sample_data+"/ta_ncep_87-6-88-4.nc")
         data = f("ta", longitude=(12,12,'cob'), latitude=(12, 12, 'cob'), squeeze=1)
-        if isinstance(method, vcs.vector.Gv):
+        if isinstance(method, vcs.vector.Gv) or \
+           isinstance(method, vcs.streamline.Gs):
             data2 = data
         else:
             data2 = None
@@ -28,7 +30,8 @@ class TestVCSAxisConvert(basevcstest.VCSBaseTest):
 
     def axisConvertGmAreaWt(self, method):
         method = method()
-        if isinstance(method, vcs.vector.Gv):
+        if isinstance(method, vcs.vector.Gv) or \
+           isinstance(method, vcs.streamline.Gs):
             data = self.clt("u")
             data2 = self.clt("v")
         elif isinstance(method, vcs.meshfill.Gfm):
@@ -51,11 +54,12 @@ class TestVCSAxisConvert(basevcstest.VCSBaseTest):
 
     def test_areawt(self):
         for method in [
-                vcs.createboxfill,
-                vcs.createisofill,
-                vcs.createisoline,
-                vcs.createmeshfill,
-        #        vcs.createvector,
+                # vcs.createboxfill,
+                # vcs.createisofill,
+                # vcs.createisoline,
+                # vcs.createmeshfill,
+                vcs.createvector,
+                #vcs.createstreamline,
                        ]:
             self.axisConvertGmAreaWt(method)
             if not method in [vcs.createmeshfill,]:

--- a/tests/test_vcs_axisconvert_2d.py
+++ b/tests/test_vcs_axisconvert_2d.py
@@ -58,8 +58,8 @@ class TestVCSAxisConvert(basevcstest.VCSBaseTest):
                 # vcs.createisofill,
                 # vcs.createisoline,
                 # vcs.createmeshfill,
-                vcs.createvector,
-                #vcs.createstreamline,
+                # vcs.createvector,
+                vcs.createstreamline,
                        ]:
             self.axisConvertGmAreaWt(method)
             if not method in [vcs.createmeshfill,]:

--- a/tests/test_vcs_axisconvert_2d.py
+++ b/tests/test_vcs_axisconvert_2d.py
@@ -54,12 +54,12 @@ class TestVCSAxisConvert(basevcstest.VCSBaseTest):
 
     def test_areawt(self):
         for method in [
-                # vcs.createboxfill,
-                # vcs.createisofill,
-                # vcs.createisoline,
-                # vcs.createmeshfill,
-                # vcs.createvector,
-                vcs.createstreamline,
+                vcs.createboxfill,
+                vcs.createisofill,
+                vcs.createisoline,
+                vcs.createmeshfill,
+                vcs.createvector,
+                # vcs.createstreamline,
                        ]:
             self.axisConvertGmAreaWt(method)
             if not method in [vcs.createmeshfill,]:

--- a/tests/test_vcs_settings_color_name_rgba_1d.py
+++ b/tests/test_vcs_settings_color_name_rgba_1d.py
@@ -7,5 +7,6 @@ class TestVCSColors1D(basevcstest.VCSBaseTest):
         gm = self.x.create1d()
         gm.linecolor = "salmon"
         gm.markercolor = [0, 0, 100]
+        gm.markersize = 2
         self.x.plot(data, gm, bg=self.bg)
         self.checkImage('test_vcs_settings_color_name_rgba_1d.png')

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -1441,11 +1441,8 @@ x.geometry(1200,800)
                 self.setLayer(self.logoRenderer, 1)
                 self.renWin.AddRenderer(self.logoRenderer)
 
-    def _applyTransformationToMapperInput(self, T, mapper):
+    def _applyTransformationToDataset(self, T, data):
         global index
-
-        mapper.Update()
-        data = mapper.GetInput()
         vcs2vtk.debugWriteGrid(data, "data" + str(index))
         vectors = data.GetPointData().GetVectors()
         data.GetPointData().SetActiveVectors(None)
@@ -1458,6 +1455,12 @@ x.geometry(1200,800)
         outputData.GetPointData().SetVectors(vectors)
         vcs2vtk.debugWriteGrid(outputData, "outputData" + str(index))
         index = index + 1
+        return outputData
+
+    def _applyTransformationToMapperInput(self, T, mapper):
+        mapper.Update()
+        data = mapper.GetInput()
+        outputData = self._applyTransformationToDataset(T, data)
         mapper.SetInputData(outputData)
 
         planeCollection = mapper.GetClippingPlanes()

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -15,6 +15,7 @@ from . import vcsvtk
 
 index = 0
 
+
 def _makeEven(val):
     if (val & 0x1):
         val -= 1
@@ -752,7 +753,7 @@ class VTKVCSBackend(object):
                     g.Update()
                     # set the markers to be rendered
                     mapper.SetInputData(g.GetOutput())
-                    #mapper.Update()
+                    # mapper.Update()
 
         elif gtype == "fillarea":
             if gm.priority != 0:

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -1508,12 +1508,22 @@ x.geometry(1200,800)
                     pass
                 if flipX:
                     cam.Azimuth(180.)
+
         T = vtk.vtkTransform()
         T.Scale(xScale, yScale, 1.)
-
-        Actor.SetUserTransform(T)
-
         mapper = Actor.GetMapper()
+        data = mapper.GetInput()
+        vectors = data.GetPointData().GetVectors()
+        data.GetPointData().SetActiveVectors(None)
+        transformFilter = vtk.vtkTransformFilter()
+        transformFilter.SetInputData(data)
+        transformFilter.SetTransform(T)
+        transformFilter.Update()
+        outputData = transformFilter.GetOutput()
+        data.GetPointData().SetVectors(vectors)
+        outputData.GetPointData().SetVectors(vectors)
+        mapper.SetInputData(outputData)
+
         planeCollection = mapper.GetClippingPlanes()
 
         # We have to transform the hardware clip planes as well

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -730,6 +730,10 @@ class VTKVCSBackend(object):
                 returned["vtk_backend_marker_actors"] = actors
                 create_renderer = True
                 for g, gs, pd, act, geo in actors:
+                    data = g.GetInput()
+                    mapper = act.GetMapper()
+                    # scale the data not the markers
+                    mapper.SetInputData(data)
                     ren, xScale, yScale = self.fitToViewport(
                         act,
                         gm.viewport,
@@ -739,8 +743,13 @@ class VTKVCSBackend(object):
                         priority=gm.priority,
                         create_renderer=create_renderer)
                     create_renderer = False
-                    if pd is None:
-                        vcs2vtk.scaleMarkerGlyph(g, gs, pd, [xScale, yScale, 1.0])
+                    # get the scaled data
+                    scaledData = mapper.GetInput()
+                    g.SetInputData(scaledData)
+                    g.Update()
+                    # set the markers to be rendered
+                    mapper.SetInputData(g.GetOutput())
+                    #mapper.Update()
 
         elif gtype == "fillarea":
             if gm.priority != 0:

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -714,7 +714,7 @@ class VTKVCSBackend(object):
                 returned["vtk_backend_line_actors"] = actors
                 create_renderer = True
                 for act, geo in actors:
-                    ren = self.fitToViewport(
+                    ren, xScale, yScale = self.fitToViewport(
                         act,
                         gm.viewport,
                         wc=gm.worldcoordinate,
@@ -730,7 +730,7 @@ class VTKVCSBackend(object):
                 returned["vtk_backend_marker_actors"] = actors
                 create_renderer = True
                 for g, gs, pd, act, geo in actors:
-                    ren = self.fitToViewport(
+                    ren, xScale, yScale = self.fitToViewport(
                         act,
                         gm.viewport,
                         wc=gm.worldcoordinate,
@@ -739,8 +739,8 @@ class VTKVCSBackend(object):
                         priority=gm.priority,
                         create_renderer=create_renderer)
                     create_renderer = False
-                    if pd is None and act.GetUserTransform():
-                        vcs2vtk.scaleMarkerGlyph(g, gs, pd, act)
+                    if pd is None:
+                        vcs2vtk.scaleMarkerGlyph(g, gs, pd, [xScale, yScale, 1.0])
 
         elif gtype == "fillarea":
             if gm.priority != 0:
@@ -1512,7 +1512,12 @@ x.geometry(1200,800)
 
         T = vtk.vtkTransform()
         T.Scale(xScale, yScale, 1.)
+
         mapper = Actor.GetMapper()
+
+
+        #Actor.SetUserTransform(T)
+
         data = mapper.GetInput()
         vcs2vtk.debugWriteGrid(data, "data" + str(index))
         vectors = data.GetPointData().GetVectors()

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -1525,8 +1525,9 @@ x.geometry(1200,800)
         mapper = Actor.GetMapper()
 
 
-        #Actor.SetUserTransform(T)
+        # Actor.SetUserTransform(T)
 
+        mapper.Update()
         data = mapper.GetInput()
         vcs2vtk.debugWriteGrid(data, "data" + str(index))
         vectors = data.GetPointData().GetVectors()

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -13,6 +13,7 @@ import inspect
 from . import VTKAnimate
 from . import vcsvtk
 
+index = 0
 
 def _makeEven(val):
     if (val & 0x1):
@@ -1430,7 +1431,7 @@ x.geometry(1200,800)
 
     def fitToViewport(self, Actor, vp, wc=None, geoBounds=None, geo=None, priority=None,
                       create_renderer=False, add_actor=True):
-
+        global index
         # Data range in World Coordinates
         if priority == 0:
             return (None, 1, 1)
@@ -1513,6 +1514,7 @@ x.geometry(1200,800)
         T.Scale(xScale, yScale, 1.)
         mapper = Actor.GetMapper()
         data = mapper.GetInput()
+        vcs2vtk.debugWriteGrid(data, "data" + str(index))
         vectors = data.GetPointData().GetVectors()
         data.GetPointData().SetActiveVectors(None)
         transformFilter = vtk.vtkTransformFilter()
@@ -1522,6 +1524,8 @@ x.geometry(1200,800)
         outputData = transformFilter.GetOutput()
         data.GetPointData().SetVectors(vectors)
         outputData.GetPointData().SetVectors(vectors)
+        vcs2vtk.debugWriteGrid(outputData, "outputData" + str(index))
+        index = index + 1
         mapper.SetInputData(outputData)
 
         planeCollection = mapper.GetClippingPlanes()

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -1479,7 +1479,8 @@ def prepFillarea(context, renWin, farea, cmap=None):
                                                 priority=farea.priority,
                                                 create_renderer=True)
     actors.append((a, geo))
-    transform = a.GetUserTransform()
+    transform = vtk.vtkTransform()
+    transform.Scale(xscale, yscale, 1.)
 
     # Patterns/hatches support
     for i, pd in pattern_polydatas:
@@ -1721,10 +1722,9 @@ def setMarkerColor(p, marker, c, cmap=None):
     p.SetOpacity(color[-1])
 
 
-def scaleMarkerGlyph(g, gs, pd, a):
+def scaleMarkerGlyph(g, gs, pd, scale):
     # Invert the scale of the actor's transform.
     glyphTransform = vtk.vtkTransform()
-    scale = a.GetUserTransform().GetScale()
     xComp = scale[0]
     scale = [xComp / float(val) for val in scale]
     glyphTransform.Scale(scale)

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -15,6 +15,27 @@ from .vcsvtk import fillareautils
 import sys
 import numbers
 
+_DEBUG_VTK = True
+
+
+def debugWriteGrid(grid, name):
+    if (_DEBUG_VTK):
+        writer = vtk.vtkXMLDataSetWriter()
+        gridType = grid.GetDataObjectType()
+        if (gridType == vtk.VTK_STRUCTURED_GRID):
+            ext = ".vts"
+        elif (gridType == vtk.VTK_UNSTRUCTURED_GRID):
+            ext = ".vtu"
+        elif (gridType == vtk.VTK_POLY_DATA):
+            ext = ".vtp"
+        else:
+            print "Unknown grid type: %d" % gridType
+            ext = ".vtk"
+        writer.SetFileName(name + ext)
+        writer.SetInputData(grid)
+        writer.Write()
+
+
 f = open(os.path.join(sys.prefix, "share", "vcs", "wmo_symbols.json"))
 wmo = json.load(f)
 
@@ -579,6 +600,9 @@ def genGrid(data1, data2, gm, deep=True, grid=None, geo=None, genVectors=False,
     globalIds = numpy_to_vtk_wrapper(numpy.arange(0, vg.GetNumberOfCells()), deep=True)
     globalIds.SetName('GlobalIds')
     vg.GetCellData().SetGlobalIds(globalIds)
+
+    debugWriteGrid(vg, "vg")
+    
     out = {"vtk_backend_grid": vg,
            "xm": xm,
            "xM": xM,

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -602,7 +602,7 @@ def genGrid(data1, data2, gm, deep=True, grid=None, geo=None, genVectors=False,
     vg.GetCellData().SetGlobalIds(globalIds)
 
     debugWriteGrid(vg, "vg")
-    
+
     out = {"vtk_backend_grid": vg,
            "xm": xm,
            "xM": xM,

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -1462,6 +1462,9 @@ def prepFillarea(context, renWin, farea, cmap=None):
     # Transform points
     geo, pts = project(pts, farea.projection, farea.worldcoordinate)
     polygonPolyData.SetPoints(pts)
+
+    debugWriteGrid(polygonPolyData, "fillarea")
+
     # for concave polygons
     tris = vtk.vtkTriangleFilter()
     tris.SetInputData(polygonPolyData)

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -1542,7 +1542,7 @@ def prepGlyph(g, marker, index=0):
         gs.SetGlyphTypeToCircle()
         gs.FilledOn()
         gs.SetResolution(25)
-        s /= 5.  # We want tiny dots not filled circles
+        s /= 300.  # We want tiny dots not filled circles
     elif t == 'circle':
         gs.SetGlyphTypeToCircle()
         gs.FilledOff()
@@ -1720,24 +1720,6 @@ def setMarkerColor(p, marker, c, cmap=None):
         color = c
     p.SetColor([C / 100. for C in color[:3]])
     p.SetOpacity(color[-1])
-
-
-def scaleMarkerGlyph(g, gs, pd, scale):
-    # Invert the scale of the actor's transform.
-    glyphTransform = vtk.vtkTransform()
-    xComp = scale[0]
-    scale = [xComp / float(val) for val in scale]
-    glyphTransform.Scale(scale)
-
-    glyphFixer = vtk.vtkTransformPolyDataFilter()
-    glyphFixer.SetTransform(glyphTransform)
-
-    if pd is None:
-        glyphFixer.SetInputConnection(gs.GetOutputPort())
-    else:
-        glyphFixer.SetInputData(pd)
-        g.SetSourceData(None)
-    g.SetSourceConnection(glyphFixer.GetOutputPort())
 
 
 def prepMarker(renWin, marker, cmap=None):

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -15,7 +15,7 @@ from .vcsvtk import fillareautils
 import sys
 import numbers
 
-_DEBUG_VTK = True
+_DEBUG_VTK = False
 
 
 def debugWriteGrid(grid, name):

--- a/vcs/vcsvtk/boxfillpipeline.py
+++ b/vcs/vcsvtk/boxfillpipeline.py
@@ -81,7 +81,6 @@ class BoxfillPipeline(Pipeline2D):
             [self._template.data.x1, self._template.data.x2,
              self._template.data.y1, self._template.data.y2])
         dataset_renderer = None
-        xScale, yScale = (1, 1)
         fareapixelspacing, fareapixelscale = self._patternSpacingAndScale()
 
         for mapper in self._mappers:
@@ -120,7 +119,8 @@ class BoxfillPipeline(Pipeline2D):
                     c = self.getColorIndexOrRGBA(_colorMap, tmpColors[cti][ctj])
 
                     # Get the transformed contour data
-                    transform = act.GetUserTransform()
+                    transform = vtk.vtkTransform()
+                    transform.Scale(xScale, yScale, 1.)
                     transformFilter = vtk.vtkTransformFilter()
                     transformFilter.SetInputData(mapper.GetInput())
                     transformFilter.SetTransform(transform)

--- a/vcs/vcsvtk/boxfillpipeline.py
+++ b/vcs/vcsvtk/boxfillpipeline.py
@@ -119,15 +119,16 @@ class BoxfillPipeline(Pipeline2D):
                     c = self.getColorIndexOrRGBA(_colorMap, tmpColors[cti][ctj])
 
                     # Get the transformed contour data
-                    transform = vtk.vtkTransform()
-                    transform.Scale(xScale, yScale, 1.)
-                    transformFilter = vtk.vtkTransformFilter()
-                    transformFilter.SetInputData(mapper.GetInput())
-                    transformFilter.SetTransform(transform)
-                    transformFilter.Update()
+                    # transform = vtk.vtkTransform()
+                    # transform.Scale(xScale, yScale, 1.)
+                    # transformFilter = vtk.vtkTransformFilter()
+                    # transformFilter.SetInputData(mapper.GetInput())
+                    # transformFilter.SetTransform(transform)
+                    # transformFilter.Update()
 
                     patact = fillareautils.make_patterned_polydata(
-                        transformFilter.GetOutput(),
+                        # transformFilter.GetOutput(),
+                        mapper.GetInput(),
                         fillareastyle=_style,
                         fillareaindex=self._customBoxfillArgs["tmpIndices"][cti],
                         fillareacolors=c,

--- a/vcs/vcsvtk/isofillpipeline.py
+++ b/vcs/vcsvtk/isofillpipeline.py
@@ -148,7 +148,8 @@ class IsofillPipeline(Pipeline2D):
                 c = self.getColorIndexOrRGBA(_colorMap, tmpColors[ct][0])
 
                 # Get the transformed contour data
-                transform = act.GetUserTransform()
+                transform = vtk.vtkTransform()
+                transform.Scale(xScale, yScale, 1.)
                 transformFilter = vtk.vtkTransformFilter()
                 transformFilter.SetInputData(mapper.GetInput())
                 transformFilter.SetTransform(transform)

--- a/vcs/vcsvtk/isofillpipeline.py
+++ b/vcs/vcsvtk/isofillpipeline.py
@@ -147,15 +147,17 @@ class IsofillPipeline(Pipeline2D):
                 # Since pattern creation requires a single color, assuming the first
                 c = self.getColorIndexOrRGBA(_colorMap, tmpColors[ct][0])
 
-                # Get the transformed contour data
-                transform = vtk.vtkTransform()
-                transform.Scale(xScale, yScale, 1.)
-                transformFilter = vtk.vtkTransformFilter()
-                transformFilter.SetInputData(mapper.GetInput())
-                transformFilter.SetTransform(transform)
-                transformFilter.Update()
+                # # Get the transformed contour data
+                # transform = vtk.vtkTransform()
+                # transform.Scale(xScale, yScale, 1.)
+                # transformFilter = vtk.vtkTransformFilter()
+                # transformFilter.SetInputData(mapper.GetInput())
+                # transformFilter.SetTransform(transform)
+                # transformFilter.Update()
 
-                patact = fillareautils.make_patterned_polydata(transformFilter.GetOutput(),
+                # patact = fillareautils.make_patterned_polydata(transformFilter.GetOutput(),
+
+                patact = fillareautils.make_patterned_polydata(mapper.GetInput(),
                                                                fillareastyle=style,
                                                                fillareaindex=tmpIndices[ct],
                                                                fillareacolors=c,

--- a/vcs/vcsvtk/meshfillpipeline.py
+++ b/vcs/vcsvtk/meshfillpipeline.py
@@ -206,7 +206,7 @@ class MeshfillPipeline(Pipeline2D):
 
                     # Get the transformed contour data
                     transform = vtk.vtkTransform()
-                    transform.Scale(xscale, yscale, 1.)
+                    transform.Scale(xScale, yScale, 1.)
                     transformFilter = vtk.vtkTransformFilter()
                     transformFilter.SetInputData(mapper.GetInput())
                     transformFilter.SetTransform(transform)

--- a/vcs/vcsvtk/meshfillpipeline.py
+++ b/vcs/vcsvtk/meshfillpipeline.py
@@ -205,7 +205,8 @@ class MeshfillPipeline(Pipeline2D):
                     c = self.getColorIndexOrRGBA(_colorMap, tmpColors[cti][ctj])
 
                     # Get the transformed contour data
-                    transform = act.GetUserTransform()
+                    transform = vtk.vtkTransform()
+                    transform.Scale(xscale, yscale, 1.)
                     transformFilter = vtk.vtkTransformFilter()
                     transformFilter.SetInputData(mapper.GetInput())
                     transformFilter.SetTransform(transform)

--- a/vcs/vcsvtk/meshfillpipeline.py
+++ b/vcs/vcsvtk/meshfillpipeline.py
@@ -205,14 +205,15 @@ class MeshfillPipeline(Pipeline2D):
                     c = self.getColorIndexOrRGBA(_colorMap, tmpColors[cti][ctj])
 
                     # Get the transformed contour data
-                    transform = vtk.vtkTransform()
-                    transform.Scale(xScale, yScale, 1.)
-                    transformFilter = vtk.vtkTransformFilter()
-                    transformFilter.SetInputData(mapper.GetInput())
-                    transformFilter.SetTransform(transform)
-                    transformFilter.Update()
+                    # transform = vtk.vtkTransform()
+                    # transform.Scale(xScale, yScale, 1.)
+                    # transformFilter = vtk.vtkTransformFilter()
+                    # transformFilter.SetInputData(mapper.GetInput())
+                    # transformFilter.SetTransform(transform)
+                    # transformFilter.Update()
 
-                    patact = fillareautils.make_patterned_polydata(transformFilter.GetOutput(),
+                    # patact = fillareautils.make_patterned_polydata(transformFilter.GetOutput(),
+                    patact = fillareautils.make_patterned_polydata(mapper.GetInput(),
                                                                    fillareastyle=style,
                                                                    fillareaindex=tmpIndices[cti],
                                                                    fillareacolors=c,

--- a/vcs/vcsvtk/vectorpipeline.py
+++ b/vcs/vcsvtk/vectorpipeline.py
@@ -177,11 +177,6 @@ class VectorPipeline(Pipeline2D):
             create_renderer=True)
         # We get the scaled data.
         newPolyData = mapper.GetInput()
-        if self._gm.scaletype == 'normalize' or self._gm.scaletype == 'constantNNormalize':
-            length = newPolyData.GetLength()
-            # max size of a glyph
-            length = length / 50
-            scaleFactor = scaleFactor * length
         glyphFilter.SetScaleFactor(scaleFactor)
         glyphFilter.SetInputData(newPolyData)
         glyphFilter.Update()

--- a/vcs/vcsvtk/vectorpipeline.py
+++ b/vcs/vcsvtk/vectorpipeline.py
@@ -19,7 +19,6 @@ class VectorPipeline(Pipeline2D):
         # Preserve time and z axis for plotting these inof in rendertemplate
         projection = vcs.elements["projection"][self._gm.projection]
         taxis = self._originalData1.getTime()
-        scaleFactor = 1.0
 
         if self._originalData1.ndim > 2:
             zaxis = self._originalData1.getAxis(-3)
@@ -27,17 +26,17 @@ class VectorPipeline(Pipeline2D):
             zaxis = None
 
         scale = 1.0
-        lat = None
-        lon = None
-
-        latAccessor = self._data1.getLatitude()
-        lonAccessor = self._data1.getLongitude()
-        if latAccessor:
-            lat = latAccessor[:]
-        if lonAccessor:
-            lon = lonAccessor[:]
 
         if self._vtkGeoTransform is not None:
+            lat = None
+            lon = None
+
+            latAccessor = self._data1.getLatitude()
+            lonAccessor = self._data1.getLongitude()
+            if latAccessor:
+                lat = latAccessor[:]
+            if lonAccessor:
+                lon = lonAccessor[:]
             newv = vtk.vtkDoubleArray()
             newv.SetNumberOfComponents(3)
             newv.InsertTypedTuple(0, [lon.min(), lat.min(), 0])
@@ -97,7 +96,6 @@ class VectorPipeline(Pipeline2D):
             scaleFactor = 1.0
 
         glyphFilter = vtk.vtkGlyph2D()
-        glyphFilter.SetInputData(polydata)
         glyphFilter.SetInputArrayToProcess(1, 0, 0, 0, "vector")
         glyphFilter.SetSourceConnection(arrow.GetOutputPort())
         glyphFilter.SetVectorModeToUseVector()
@@ -147,17 +145,13 @@ class VectorPipeline(Pipeline2D):
                 # and not remap the range.
                 glyphFilter.SetScaleModeToScaleByScalar()
 
-        glyphFilter.SetScaleFactor(scaleFactor)
         if (maxNormInVp is None):
             maxNormInVp = maxNorm * scaleFactor
             # minNormInVp is left None, as it is displayed only for linear scaling.
 
         mapper = vtk.vtkPolyDataMapper()
 
-        glyphFilter.Update()
-        data = glyphFilter.GetOutput()
-
-        mapper.SetInputData(data)
+        mapper.SetInputData(polydata)
         mapper.ScalarVisibilityOff()
         act = vtk.vtkActor()
         act.SetMapper(mapper)
@@ -173,6 +167,7 @@ class VectorPipeline(Pipeline2D):
         vp = self._resultDict.get('ratio_autot_viewport',
                                   [self._template.data.x1, self._template.data.x2,
                                    self._template.data.y1, self._template.data.y2])
+
         dataset_renderer, xScale, yScale = self._context().fitToViewport(
             act, vp,
             wc=plotting_dataset_bounds,
@@ -180,6 +175,22 @@ class VectorPipeline(Pipeline2D):
             geo=self._vtkGeoTransform,
             priority=self._template.data.priority,
             create_renderer=True)
+        # We get the scaled data.
+        newPolyData = mapper.GetInput()
+        if self._gm.scaletype == 'normalize' or self._gm.scaletype == 'constantNNormalize':
+            length = newPolyData.GetLength()
+            # max size of a glyph
+            length = length / 50
+            scaleFactor = scaleFactor * length
+        glyphFilter.SetScaleFactor(scaleFactor)
+        glyphFilter.SetInputData(newPolyData)
+        glyphFilter.Update()
+        # and set the arrows to be rendered.
+
+        data = glyphFilter.GetOutput()
+        vcs2vtk.debugWriteGrid(data, "glyph")
+        mapper.SetInputData(data)
+
         kwargs = {'vtk_backend_grid': self._vtkDataSet,
                   'dataset_bounds': self._vtkDataSetBounds,
                   'plotting_dataset_bounds': plotting_dataset_bounds,

--- a/vcs/vector.py
+++ b/vcs/vector.py
@@ -613,10 +613,10 @@ class Gv(vcs.bestMatch):
     """
     One of the following strings:
       off - No scaling is performed on the vector values
-      constant - vector value *  self.scale
-      normalize - vector value /  max_norm
-      constantNNormalize - vector value * self.scale / max_norm
-      linear - map [min_norm, max_norm] to self.scalerange
+      constant: vector value *  self.scale
+      normalize: vector value /  max_norm
+      constantNNormalize: vector value * self.scale / max_norm
+      linear: map [min_norm, max_norm] to self.scalerange
       constantNLinear - map [min_norm, max_norm] to self.scalerange and then multiply by self.scale
     """
     def _getscaletype(self):


### PR DESCRIPTION
These are the remaining test failures on this topic, categorized.  The ones marked by an "X" seem to be fixed.

animation tests

 - [X] test_vcs_animate_boxfill.py
 - [X] test_vcs_animate_isofill.py
 - [X] test_vcs_animate_isoline.py
 - [X] test_vcs_animate_isoline_colored.py
 - [X] test_vcs_animate_isoline_text_labels.py
 - [X] test_vcs_animate_isoline_text_labels_colored.py
 - [X] test_vcs_animate_meshfill.py
 - [X] test_vcs_gms_animate_projected_plots.py

marker size

- [ ] test_vcs_1D_marker_not_shown_if_xaxis_flipped
- [ ] test_vcs_1D_mintics
- [ ] test_vcs_basic_gms_2
- [ ] test_vcs_drawLinesAndMarkersLegend
- [ ] test_vcs_markers
- [ ] test_vcs_markers_uniform_size_2
- [ ] test_vcs_taylor_2quads
- [ ] test_vcs_taylor_basic
- [ ] test_vcs_taylor_lines
- [ ] test_vcs_taylor_markers
- [ ] test_vcs_taylor_skills
- [ ] test_vcs_taylor_stdlabel
- [ ] test_vcs_taylor_template_ctl
- [ ] test_vcs_taylor_template_legend
- [ ] test_vcs_vectors_scale_options
- [ ] test_vcs_wmo_markers

style/format issue

- [X] test_vcs_flake8

widget size

- [ ] test_vcs_configurator_resize

need new/updated baseline

- [ ] test_vcs_axisconvert_2d
- [ ] test_vcs_isoline_extend_attributes
- [ ] test_vcs_isoline_width_stipple

pattern horizontal scaling issue

- [X] test_vcs_gms_patterns_hatches
- [X] test_vcs_hatches_patterns
- [X] test_vcs_large_pattern_hatch

matplotlib import error (has six version 1.7.2, needs >= 1.10)

- [ ] test_vcs_load_mpl_cmaps
- [ ] test_vcs_matplotlib_colormap

unknown (appears successful)

- [X] test_vcs_png_to_base64

vector scaling

- [ ] test_vcs_vectors_scale_options
- [ ] test_vcs_vectors_warp
