### PR TITLE
add README.md with just the circleci status badge and coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+[![CircleCI](https://circleci.com/gh/CDAT/vcs.svg?style=svg)](https://circleci.com/gh/CDAT/vcs)
+[![Coverage Status](https://coveralls.io/repos/github/CDAT/vcs/badge.svg?branch=master)](https://coveralls.io/github/CDAT/vcs?branch=master)


### PR DESCRIPTION
add a README.md that has status badge for circleci status and coveralls status.
(left out from my previous push).