### PR TITLE
only need to upload once now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - run: *create_conda_env
       - run: *setup_vcs
       - run: *run_vcs_tests
-      - run: *conda_upload
+        #- run: *conda_upload
       - store_artifacts:
           path: tests_html
           destination: tests_html
@@ -137,7 +137,7 @@ jobs:
       - run: *create_conda_env
       - run: *setup_vcs
       - run: *run_vcs_tests
-      - run: *conda_upload
+        #- run: *conda_upload
       - store_artifacts:
           path: tests_html
           destination: tests_html
@@ -159,7 +159,7 @@ jobs:
       - run: *create_conda_env
       - run: *setup_vcs
       - run: *run_vcs_tests
-      - run: *conda_upload
+        # - run: *conda_upload
       - store_artifacts:
           path: tests_html
           destination: tests_html

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,1 +1,0 @@
-python setup.py install

--- a/recipe/meta.yaml.in
+++ b/recipe/meta.yaml.in
@@ -8,12 +8,16 @@ source:
 
 build:
   number: @BUILD_NUMBER@
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
  
 requirements:
   build:
     - python
     - setuptools
     - cdat_info
+    - pip
   run:
     - python
     - cdat_info


### PR DESCRIPTION
@muryanto1 please review. This makes vcs conda independent of OS and py version, so we only need to upload once (I picked py3 linux) Do you know if there is a way to run only linux_py3 if it the master branch? Since it passed on the branch we shouldn't bother with rerunning everything again now that we do not need to upload from each os.