### PR TITLE
Fix vectorpipeline which did not respect gm.linewidth

### DIFF
--- a/tests/test_vcs_vectors_linewidth.py
+++ b/tests/test_vcs_vectors_linewidth.py
@@ -1,0 +1,37 @@
+import basevcstest
+import numpy as np
+import cdms2
+
+
+class TestVCSVectorLineWidth(basevcstest.VCSBaseTest):
+    def lineWidthTest(self, lineWidth=1.0):
+        u = cdms2.createAxis(np.array([[1, 1, 0, 1, 1, 1, 0, 1],
+                                       [1, 1, 0, 1, 1, 1, 0, 1],
+                                       [1, 1, 0, 1, 1, 1, 0, 1],
+                                       [1, 1, 0, 1, 1, 1, 0, 1],
+                                       [1, 1, 0, 1, 1, 1, 0, 1],
+                                       [1, 1, 0, 1, 1, 1, 0, 1],
+                                       [1, 1, 0, 1, 1, 1, 0, 1],
+                                       [1, 1, 0, 1, 1, 1, 0, 1]]))
+        u.id = "u"
+        v = cdms2.createAxis(np.array([[1, 0, 1, 0.5, 1, 0, 1, 0.5],
+                                       [1, 0, 1, 0.5, 1, 0, 1, 0.5],
+                                       [1, 0, 1, 0.5, 1, 0, 1, 0.5],
+                                       [1, 0, 1, 0.5, 1, 0, 1, 0.5],
+                                       [1, 0, 1, 0.5, 1, 0, 1, 0.5],
+                                       [1, 0, 1, 0.5, 1, 0, 1, 0.5],
+                                       [1, 0, 1, 0.5, 1, 0, 1, 0.5],
+                                       [1, 0, 1, 0.5, 1, 0, 1, 0.5]]))
+        v.id = "v"
+
+        gv = self.x.createvector()
+        gv.linewidth = lineWidth
+        self.x.plot(u, v, gv, bg=self.bg, ratio=1)
+        label = lineWidth
+        outFilename = 'test_vcs_vectors_linewidth_%s.png' % label
+        self.checkImage(outFilename)
+        self.x.clear()
+
+    def testVCSVectorLineWidthOptions(self):
+        for lw in [1.0, 5.0, 10.0]:
+            self.lineWidthTest(lineWidth=lw)

--- a/vcs/vcsvtk/vectorpipeline.py
+++ b/vcs/vcsvtk/vectorpipeline.py
@@ -198,6 +198,12 @@ class VectorPipeline(Pipeline2D):
 
         data = glyphFilter.GetOutput()
 
+        floatValue = vtk.vtkFloatArray()
+        floatValue.SetNumberOfComponents(1)
+        floatValue.SetName("LineWidth")
+        floatValue.InsertNextValue(lwidth)
+        data.GetFieldData().AddArray(floatValue)
+
         item = vtk.vtkPolyDataItem()
         item.SetPolyData(data)
 


### PR DESCRIPTION
Should hopefully address #381, but let's not close it until we get confirmation.