### PR TITLE
Add support for the 'reference' attribute on the vector gm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,3 +218,4 @@ workflows:
   vcs:
     jobs:
       - macos_vcs_py3:
+      - linux_vcs_py3:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
     name: create_conda_env
     environment:
        CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-       PKGS: "cdms2 'libcdms>=3.1.2' cdat_info udunits2 testsrunner mesalib matplotlib image-compare genutil dv3d cdutil cdtime nbformat 'proj4<5' 'numpy>1.14' ghostscript vtk-cdat"
+       PKGS: "cdms2 cdat_info udunits2 testsrunner mesalib matplotlib image-compare genutil dv3d cdutil cdtime nbformat 'proj4<5' numpy ghostscript vtk-cdat"
     command: |
        export PATH=$WORKDIR/miniconda/bin:$PATH
        conda config --set always_yes yes --set changeps1 no

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ aliases:
        if [[ $PY_VER = "py2" ]]; then
           conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python<3"
        else
-          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python=3.7" nbsphinx easydev $COVERAGE_PKGS
+          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python=3.6" nbsphinx easydev $COVERAGE_PKGS
        fi
 
   - &setup_vcs
@@ -208,11 +208,11 @@ workflows:
   version: 2
   vcs:
     jobs:
-#      - macos_vcs_py2
-      - macos_vcs_py3
-#           requires:
-#              - macos_vcs_py2
-#      - linux_vcs_py2
-#      - linux_vcs_py3:
-#           requires:
-#              - linux_vcs_py2
+      - macos_vcs_py2
+      - macos_vcs_py3:
+           requires:
+              - macos_vcs_py2
+      - linux_vcs_py2
+      - linux_vcs_py3:
+           requires:
+              - linux_vcs_py2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,10 +218,3 @@ workflows:
   vcs:
     jobs:
       - macos_vcs_py3:
-#      - macos_vcs_py2
-#           requires:
-#              - macos_vcs_py2
-#      - linux_vcs_py2
-#      - linux_vcs_py3:
-#           requires:
-#              - linux_vcs_py2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ aliases:
        if [[ $PY_VER = "py2" ]]; then
           conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python<3"
        else
-          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python=3.6" nbsphinx easydev $COVERAGE_PKGS
+          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python=3.7" nbsphinx easydev $COVERAGE_PKGS
        fi
 
   - &setup_vcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
       OS: "osx-64"
       PY_VER: "py2"
       TEMP_PKGS: "'ffmpeg>4' 'libpng>1.6.34'"
-      CUSTOM_CHANNELS: "-c danlipsa"
+      CUSTOM_CHANNELS: ""
     steps:
       - checkout
       - run: *setup_miniconda
@@ -145,13 +145,13 @@ jobs:
 
   macos_vcs_py3:
     macos:
-      xcode: "9.2.0"
+      xcode: "10.2.0"
     environment:
       WORKDIR: "workspace/test_macos_vcs_py3"
       OS: "osx-64"
       PY_VER: "py3"
       TEMP_PKGS: "'ffmpeg>4' 'libpng>1.6.34'"
-      CUSTOM_CHANNELS: "-c danlipsa"
+      CUSTOM_CHANNELS: ""
     steps:
       - checkout
       - run: *setup_miniconda
@@ -217,11 +217,11 @@ workflows:
   version: 2
   vcs:
     jobs:
-      - macos_vcs_py2
+#      - macos_vcs_py2
       - macos_vcs_py3:
-           requires:
-              - macos_vcs_py2
-      - linux_vcs_py2
-      - linux_vcs_py3:
-           requires:
-              - linux_vcs_py2
+#           requires:
+#              - macos_vcs_py2
+#      - linux_vcs_py2
+#      - linux_vcs_py3:
+#           requires:
+#              - linux_vcs_py2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ aliases:
        if [[ $PY_VER = "py2" ]]; then
           conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python<3"
        else
-          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python>=3.7" nbsphinx easydev $COVERAGE_PKGS
+          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python=3.6" nbsphinx easydev $COVERAGE_PKGS
        fi
 
   - &setup_vcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,17 +22,16 @@ aliases:
     name: create_conda_env
     environment:
        CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-       PKGS: "cdms2 cdat_info udunits2 testsrunner mesalib matplotlib image-compare genutil dv3d cdutil cdtime nbformat 'vtk-cdat<8.2.0.rc2.289.8.0.2019.01.28.16' 'proj4<5' 'numpy>1.14' ghostscript"
+       PKGS: "cdms2 'libcdms>=3.1.2' cdat_info udunits2 testsrunner mesalib matplotlib image-compare genutil dv3d cdutil cdtime nbformat 'proj4<5' 'numpy>1.14' ghostscript vtk-cdat"
     command: |
        export PATH=$WORKDIR/miniconda/bin:$PATH
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
-       conda install -n base "conda<4.6"
        conda config --set anaconda_upload no
        if [[ $PY_VER = "py2" ]]; then
           conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python<3"
        else
-          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python>3" nbsphinx easydev $COVERAGE_PKGS
+          conda create -q -n $PY_VER $CUSTOM_CHANNELS $CHANNELS $PKGS $TEMP_PKGS "python>=3.7" nbsphinx easydev $COVERAGE_PKGS
        fi
 
   - &setup_vcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,14 +70,6 @@ aliases:
        fi
        exit $RESULT
 
-  - &templink
-    name: templink
-    command: |
-       export PATH=$WORKDIR/miniconda/bin:$PATH
-       source activate $PY_VER
-       rm ${WORKDIR}/miniconda/envs/$PY_VER/bin/python
-       ln -s $(pwd)/$WORKDIR/miniconda/envs/$PY_VER/bin/vtkpython $(pwd)/$WORKDIR/miniconda/envs/$PY_VER/bin/python
-        
   - &conda_upload
     name: conda_upload
     environment:
@@ -157,7 +149,6 @@ jobs:
       - run: *setup_miniconda
       - run: *get_testdata
       - run: *create_conda_env
-      - run: *templink
       - run: *setup_vcs
       - run: *run_vcs_tests
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,5 +217,11 @@ workflows:
   version: 2
   vcs:
     jobs:
-      - macos_vcs_py3:
-      - linux_vcs_py3:
+#      - macos_vcs_py2
+      - macos_vcs_py3
+#           requires:
+#              - macos_vcs_py2
+#      - linux_vcs_py2
+#      - linux_vcs_py3:
+#           requires:
+#              - linux_vcs_py2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,8 +217,8 @@ workflows:
   version: 2
   vcs:
     jobs:
-#      - macos_vcs_py2
       - macos_vcs_py3:
+#      - macos_vcs_py2
 #           requires:
 #              - macos_vcs_py2
 #      - linux_vcs_py2

--- a/recipe/meta.yaml.in
+++ b/recipe/meta.yaml.in
@@ -23,6 +23,7 @@ requirements:
     - cdat_info
     - genutil
     - dv3d
+    - libcdms >=3.1.2
     - vtk-cdat >8.1
     - cdms2
     - cdutil

--- a/tests/test_vcs_vectors_scale.py
+++ b/tests/test_vcs_vectors_scale.py
@@ -6,7 +6,7 @@ import cdms2
 
 
 class TestVCSVectorScale(basevcstest.VCSBaseTest):
-    def coreTest(self, scalingType, scale=None, scalerange=None):
+    def coreTest(self, scalingType, scale=None, scalerange=None, ref=None):
         u = cdms2.createAxis(np.array([[1, 1, 0, 1, 1, 1, 0, 1],
                                        [1, 1, 0, 1, 1, 1, 0, 1],
                                        [1, 1, 0, 1, 1, 1, 0, 1],
@@ -32,11 +32,15 @@ class TestVCSVectorScale(basevcstest.VCSBaseTest):
             gv.scalerange = scalerange
         if scale is not None:
             gv.scale = scale
+        if ref is not None:
+            gv.reference = ref
         self.x.plot(u, v, gv, bg=self.bg, ratio=1)
         label = scalingType
         if (scalingType == "constant"):
             label += "_" + str(scale)
         outFilename = 'test_vcs_vectors_scale_%s.png' % label
+        if ref is not None:
+            outFilename = 'test_vcs_vectors_scale_%s_ref_%s.png' % (label, ref)
         self.checkImage(outFilename)
         self.x.clear()
 
@@ -50,4 +54,8 @@ class TestVCSVectorScale(basevcstest.VCSBaseTest):
         # test clamping
         self.coreTest("constant", scale=0.1)
         self.coreTest("constant", scale=2)
+        # test reference
+        self.coreTest("constant", scale=0.5, ref=1)
+        self.coreTest("constant", scale=0.1, ref=5)
+        self.coreTest("constant", scale=2, ref=0.5)
     testVCSVectorScalingOptions.vectors = 1

--- a/vcs/vcsvtk/vectorpipeline.py
+++ b/vcs/vcsvtk/vectorpipeline.py
@@ -245,7 +245,7 @@ class VectorPipeline(Pipeline2D):
             minNormInVp *= worldToViewportXScale
         vcs.utils.drawVectorLegend(
             self._context().canvas, self._template.legend, lcolor, lstyle, lwidth,
-            unitString, maxNormInVp, maxNorm, minNormInVp, minNorm)
+            unitString, maxNormInVp, maxNorm, minNormInVp, minNorm, reference=self._gm.reference)
 
         kwargs['xaxisconvert'] = self._gm.xaxisconvert
         kwargs['yaxisconvert'] = self._gm.yaxisconvert

--- a/vcs/vector.py
+++ b/vcs/vector.py
@@ -308,7 +308,10 @@ class Gv(vcs.bestMatch):
 
             .. code-block:: python
 
-                # Can be an integer or float
+                # Can be an integer or float.  Setting the reference attribute
+                # overrides the default behavior of picking a reasonable size
+                # for the vector legend arrow.  This may result in a very large
+                # or very small arrow, depending on the value of vc.reference.
                 vc.reference=4
     """
     __slots__ = [
@@ -772,7 +775,7 @@ class Gv(vcs.bestMatch):
         print("datawc_calendar = ", self.datawc_calendar)
         print("xaxisconvert = ", self.xaxisconvert)
         print("yaxisconvert = ", self.yaxisconvert)
-        print("line = ", self.line)
+        print("linetype = ", self.linetype)
         print("linecolor = ", self.linecolor)
         print("linewidth = ", self.linewidth)
         print("scale = ", self.scale)


### PR DESCRIPTION
The 'reference' attribute has been available to read/write on
the vector graphics method, but until now has not been implemented.
Now, if it is set, the default behavior of choosing a sensible value
for the arrow length based on the screen space availabe, text size,
etc., will be overridden.  Instead the arrow length will simply be
chosen to match the reference attribute.  Hence, this feature should
be used with care, as it could result in a vector legend with either
very large or very small reference arrow.