### PR TITLE
Fix test vcs generate notebook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ aliases:
     name: setup_miniconda
     command: |
        mkdir -p workspace
-       git clone -b validateNightly git@github.com:CDAT/cdat workspace/cdat
+       git clone -b validateNightlyNew git@github.com:CDAT/cdat workspace/cdat
        # install_miniconda.py installs miniconda3 under $WORKDIR/miniconda
        python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
 

--- a/tests/test_vcs_generate_notebook.py
+++ b/tests/test_vcs_generate_notebook.py
@@ -2,6 +2,7 @@ import cdat_info
 import unittest
 import nbformat
 import os
+import sys
 import vcs
 from testsrunner import run_command
 
@@ -21,7 +22,8 @@ class NBTest(unittest.TestCase):
     def test_generate_notebook_from_png(self):
         run_command("python tests/share/vcs_generate_simple_plot.py")
         metadata = vcs.png_read_metadata("test_vcs_generate_simple_plot.png")
-        cmd = "generate_cdat_notebook.py -i test_vcs_generate_simple_plot.png -o test_vcs_generate_simple_plot"
+        script = "{p}/bin/generate_cdat_notebook.py".format(p=sys.prefix)
+        cmd = "python {s} -i test_vcs_generate_simple_plot.png -o test_vcs_generate_simple_plot".format(s=script)
         code, msg = run_command(cmd)
         self.assertEqual(code, 0)
         self.assertTrue(os.path.exists("test_vcs_generate_simple_plot.ipynb"))


### PR DESCRIPTION
fix test_vcs_generate_notebook.py. 
This test started failing, not finding generate_cdat_notebook.py script, not sure what change that cause this.
I added sys.prefix to the path to the script.

Also, use 'validateNightlyNew' branch cdat/cdat repo in .circleci/config.yml.
This branch installs Miniconda3 4.7.12.1. Latest Miniconda3 installer installs 4.8.2, and it is causing exit error 247 in circleci macos build.
