### PR TITLE
pass conda_build_env=base for 'make conda-build' and 'make conda-rerender' in circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       make conda-rerender workdir=$WORKDIR branch=$CIRCLE_BRANCH
+       make conda-rerender workdir=$WORKDIR conda_build_env=base branch=$CIRCLE_BRANCH
 
   - &conda_build
     name: conda_build
@@ -36,7 +36,7 @@ aliases:
        conda activate base
        os=`uname`
        artifacts_dir="artifacts/artifacts.${os}.noarch"
-       make conda-build workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir
+       make conda-build workdir=$WORKDIR conda_build_env=base artifact_dir=$PWD/$artifacts_dir
 
   - &setup_run_tests
     name: setup_run_tests

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ endif
 
 last_stable ?= 8.2
 
-conda_test_env = test-$(pkg_name)
-conda_build_env = build-$(pkg_name)
+conda_test_env ?= test-$(pkg_name)
+conda_build_env ?= build-$(pkg_name)
 
 branch ?= $(shell git rev-parse --abbrev-ref HEAD)
 extra_channels ?= cdat/label/nightly conda-forge


### PR DESCRIPTION
+ set conda_build_env and conda_test_env to a default value in Makefile if it is not passed in.
+ pass in 'conda_build_env=base' when doing 'make conda-rerender' and 'make conda-build' in .circleci/config.yml
